### PR TITLE
features:

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.kelari.atg</groupId>
     <artifactId>kelari-spring-api-test-generator</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.6</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -14,14 +14,6 @@
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
-
-    <distributionManagement>
-        <repository>
-            <id>github</id>
-            <name>GitHub Packages</name>
-            <url>https://maven.pkg.github.com/agsn10/kelari-api-test-generator</url>
-        </repository>
-    </distributionManagement>
 
     <repositories>
         <repository>
@@ -54,6 +46,12 @@
             <version>1.13.0</version>
         </dependency>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>2.2</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.19.0</version>
@@ -62,14 +60,13 @@
 
     <build>
         <plugins>
-            <!-- Plugin para compilar com Java 8 -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>17</source>
+                    <target>17</target>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>com.google.auto.service</groupId>

--- a/src/main/java/io/github/kelari/atg/annotation/ApiTestCase.java
+++ b/src/main/java/io/github/kelari/atg/annotation/ApiTestCase.java
@@ -3,6 +3,7 @@ package io.github.kelari.atg.annotation;
 import io.github.kelari.atg.data.DataLoad;
 
 import java.lang.annotation.*;
+import java.time.Duration;
 
 /**
  * Defines the execution goals for an API test, such as execution order,
@@ -19,7 +20,7 @@ import java.lang.annotation.*;
  *     displayName = "🚀 Should create a new customer successfully",
  *     order = 1,
  *     timeout = 5,
- *     expectedStatusCodes = HttpURLConnection.HTTP_OK
+ *     expectedStatusCode = HttpURLConnection.HTTP_OK
  * )
  * }
  * </pre>
@@ -69,9 +70,9 @@ public @interface ApiTestCase {
      * Defines a class that will load test data to be used during test execution.
      * The class must implement the {@link DataLoad} interface.
      *
-     * @return a class implementing {@link DataLoad}, default is None.class (no data)
+     * @return a class implementing {@link DataLoad}, default is empty string (no provider)
      */
-    String dataProviderClassName() default "";
+    String[] dataProviderClassName() default {};
 
     /**
      * Indicates whether the test requires authentication.
@@ -80,4 +81,60 @@ public @interface ApiTestCase {
      * @return true if the endpoint requires authentication; false otherwise
      */
     boolean requiresAuth() default false;
+
+    /**
+     * Defines a list of expected JSONPath expressions and their expected values
+     * to be validated against the API response body.
+     *
+     * @return an array of {@link JsonPath} validations
+     */
+    JsonPath[] jsonPaths() default {};
+
+    /**
+     * Enables or disables logging for this specific test case.
+     * Useful for debugging or tracing execution details.
+     *
+     * @return true if logging should be enabled; false otherwise
+     */
+    boolean enableLogging() default false;
+
+    /**
+     * Indicates whether this test case should be executed as a parameterized test.
+     * Useful when executing the same logic with different inputs.
+     *
+     * @return true if the test is parameterized; false otherwise
+     */
+    //boolean parameterizedTest() default false;
+
+    /**
+     * Defines the list of HTTP headers expected to be present in the response.
+     * Useful for validating response metadata.
+     *
+     * @return an array of expected response headers
+     */
+    Header[] expectedHeaders() default {};
+
+    /**
+     * Defines the list of HTTP cookies expected to be present in the response.
+     * Useful for validating response metadata.
+     *
+     * @return an array of expected response cookies
+     */
+    Cookie[] expectedCookies() default {};
+
+    /**
+     * Defines how many times the test should be executed consecutively.
+     * Useful for stability testing or retries.
+     *
+     * @return the number of times to repeat the test
+     */
+    int repeat() default 1;
+
+    /**
+     * Defines the maximum duration to wait for a response, in seconds.
+     * Overrides the global timeout if specified.
+     *
+     * @return the response timeout in seconds; -1 means no override
+     */
+    long responseTimeoutSeconds() default -1;
 }

--- a/src/main/java/io/github/kelari/atg/annotation/ApiTestSpec.java
+++ b/src/main/java/io/github/kelari/atg/annotation/ApiTestSpec.java
@@ -1,5 +1,7 @@
 package io.github.kelari.atg.annotation;
 
+import io.github.kelari.atg.annotation.defaults.NoOpSetup;
+
 import java.lang.annotation.*;
 
 /**

--- a/src/main/java/io/github/kelari/atg/annotation/Cookie.java
+++ b/src/main/java/io/github/kelari/atg/annotation/Cookie.java
@@ -1,0 +1,44 @@
+package io.github.kelari.atg.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Represents an expected HTTP cookie in the response for an API test case.
+ * <p>
+ * This annotation is typically used as part of {@code @ApiTestCase} to assert
+ * that a cookie with the specified name and value is present in the HTTP response.
+ * </p>
+ *
+ * <pre>{@code
+ * @ApiTestCase(
+ *     expectedCookies = {
+ *         @Cookie(name = "sessionId", value = "abc123"),
+ *         @Cookie(name = "locale", value = "en-US")
+ *     }
+ * )
+ * }</pre>
+ *
+ * @author <a href="mailto:agsn10@hotmail.com">Antonio Neto</a> [<()>] – Initial implementation.
+ * @since 1.0
+ * @copyright 2025 Kelari. All rights reserved.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({})
+public @interface Cookie {
+
+    /**
+     * The name of the expected HTTP cookie.
+     *
+     * @return the cookie name
+     */
+    String name();
+
+    /**
+     * The expected value of the HTTP cookie.
+     *
+     * @return the cookie value
+     */
+    String value();
+}

--- a/src/main/java/io/github/kelari/atg/annotation/Header.java
+++ b/src/main/java/io/github/kelari/atg/annotation/Header.java
@@ -1,0 +1,45 @@
+package io.github.kelari.atg.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Represents an expected HTTP response header for an API test case.
+ * <p>
+ * This annotation is typically used inside another annotation (e.g., {@code @ApiTestCase})
+ * to declare expected headers that should be present in the HTTP response.
+ * </p>
+ *
+ * <pre>{@code
+ * @ApiTestCase(
+ *     expectedHeaders = {
+ *         @Header(name = "Content-Type", value = "application/json"),
+ *         @Header(name = "X-Custom", value = {"value1", "value2"})
+ *     }
+ * )
+ * }</pre>
+ *
+ * @author <a href="mailto:agsn10@hotmail.com">Antonio Neto</a> [<()>] – Initial implementation.
+ * @since 1.0
+ * @copyright 2025 Kelari. All rights reserved.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({})
+public @interface Header {
+
+    /**
+     * The name of the HTTP header.
+     *
+     * @return the header name
+     */
+    String name();
+
+    /**
+     * The expected value(s) for the header.
+     * If multiple values are specified, they must all be present in the response.
+     *
+     * @return the expected header values
+     */
+    String[] value();
+}

--- a/src/main/java/io/github/kelari/atg/annotation/JsonPath.java
+++ b/src/main/java/io/github/kelari/atg/annotation/JsonPath.java
@@ -1,0 +1,69 @@
+package io.github.kelari.atg.annotation;
+
+import io.github.kelari.atg.annotation.defaults.DummyMatcher;
+import org.hamcrest.Matcher;
+
+import java.lang.annotation.*;
+
+/**
+ * Annotation used to define a JSON path assertion for an API test case.
+ * <p>
+ * This annotation allows specifying a JSON path within the response body
+ * and associating it with a matcher to validate the value found at that path.
+ * Multiple {@code @JsonPath} annotations can be grouped using {@link JsonPaths}.
+ * </p>
+ *
+ * <pre>{@code
+ * @JsonPath(path = "$.data.name", type = MatcherType.EQUAL_TO, value = "Antonio Neto")
+ * }</pre>
+ *
+ * @see JsonPaths
+ * @see MatcherType
+ * @author <a href="mailto:agsn10@hotmail.com">Antonio Neto</a> [<()>] – Initial implementation.
+ * @since 1.0
+ * @copyright 2025 Kelari. All rights reserved.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Repeatable(JsonPaths.class)
+public @interface JsonPath {
+
+    /**
+     * The JSON path to evaluate in the response body.
+     * <p>Example: {@code "$.data.name"}</p>
+     *
+     * @return the JSON path expression
+     */
+    String path();
+
+    /**
+     * The type of matcher to use for the assertion.
+     * <p>Examples: {@code EQUAL_TO}, {@code NOT_NULL_VALUE}, {@code CONTAINS_STRING}</p>
+     *
+     * @return the matcher type
+     */
+    MatcherType type();
+
+    /**
+     * The expected value used in the matcher.
+     * <p>
+     * This is used for types like {@code EQUAL_TO}, {@code CONTAINS_STRING},
+     * {@code NOT}, {@code ANY_OF}, etc. For {@code INSTANCE_OF}, this should
+     * be the fully qualified class name (e.g., {@code "java.lang.Integer"}).
+     * </p>
+     *
+     * @return the expected value as a string
+     */
+    String value() default "";
+
+    /**
+     * The custom matcher class to be used when {@code type = CUSTOM_CLASS}.
+     * <p>
+     * This should be a class that implements {@link Matcher}.
+     * Ignored if {@code type} is not {@code CUSTOM_CLASS}.
+     * </p>
+     *
+     * @return the custom matcher class
+     */
+    Class<? extends Matcher<?>> matcherClass() default DummyMatcher.class;
+}

--- a/src/main/java/io/github/kelari/atg/annotation/JsonPaths.java
+++ b/src/main/java/io/github/kelari/atg/annotation/JsonPaths.java
@@ -1,0 +1,26 @@
+package io.github.kelari.atg.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * Container annotation that allows multiple {@link JsonPath} annotations to be applied
+ * to a single test method.
+ * <p>
+ * This is used implicitly when multiple {@code @JsonPath} annotations are declared
+ * on the same method.
+ *
+ * @see JsonPath
+ * @author <a href="mailto:agsn10@hotmail.com">Antonio Neto</a> [<()>] – Initial implementation.
+ * @since 1.0
+ * @copyright 2025 Kelari. All rights reserved.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface JsonPaths {
+    /**
+     * The array of {@link JsonPath} annotations.
+     *
+     * @return an array of JsonPath annotations
+     */
+    JsonPath[] value();
+}

--- a/src/main/java/io/github/kelari/atg/annotation/MatcherType.java
+++ b/src/main/java/io/github/kelari/atg/annotation/MatcherType.java
@@ -1,0 +1,67 @@
+package io.github.kelari.atg.annotation;
+
+/**
+ * Defines the types of matchers supported for JSON path assertions in API test cases.
+ *
+ * @author <a href="mailto:agsn10@hotmail.com">Antonio Neto</a> [<()>] – Initial implementation.
+ * @since 1.0
+ * @copyright 2025 Kelari. All rights reserved.
+ */
+public enum MatcherType {
+    /**
+     * Verifies that the value is exactly equal to the expected one.
+     */
+    EQUAL_TO,
+    /**
+     * Verifies that a collection contains at least one occurrence of the specified item.
+     */
+    HAS_ITEM,
+    /**
+     * Verifies that the value is {@code null}.
+     */
+    NULL_VALUE,
+    /**
+     * Verifies that the value is not {@code null}.
+     */
+    NOT_NULL_VALUE,
+    /**
+     * Applies logical negation to the specified matcher.
+     */
+    NOT,
+    /**
+     * Verifies that the value is an instance of a specified type.
+     */
+    INSTANCE_OF,
+    /**
+     * Verifies that the value is greater than the expected one.
+     */
+    GREATER_THAN,
+    /**
+     * Verifies that the value is less than the expected one.
+     */
+    LESS_THAN,
+    /**
+     * Verifies that the string contains a given substring.
+     */
+    CONTAINS_STRING,
+    /**
+     * Verifies that the string starts with a given prefix.
+     */
+    STARTS_WITH,
+    /**
+     * Verifies that the string ends with a given suffix.
+     */
+    ENDS_WITH,
+    /**
+     * Verifies that the value matches any of the provided matchers.
+     */
+    ANY_OF,
+    /**
+     * Verifies that a collection contains a specific element.
+     */
+    CONTAINS,
+    /**
+     * Uses a custom matcher class provided by the user for advanced validation logic.
+     */
+    CUSTOM_CLASS
+}

--- a/src/main/java/io/github/kelari/atg/annotation/defaults/DummyMatcher.java
+++ b/src/main/java/io/github/kelari/atg/annotation/defaults/DummyMatcher.java
@@ -1,0 +1,11 @@
+package io.github.kelari.atg.annotation.defaults;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+
+public class DummyMatcher implements Matcher<Object> {
+    @Override public boolean matches(Object item) { return false; }
+    @Override public void describeMismatch(Object item, Description description) {}
+    @Override public void describeTo(Description description) {}
+    @Override public void _dont_implement_Matcher___instead_extend_BaseMatcher_() {}
+}

--- a/src/main/java/io/github/kelari/atg/annotation/defaults/NoOpSetup.java
+++ b/src/main/java/io/github/kelari/atg/annotation/defaults/NoOpSetup.java
@@ -1,0 +1,5 @@
+package io.github.kelari.atg.annotation.defaults;
+
+public class NoOpSetup implements Runnable {
+    public void run() {}
+}

--- a/src/main/java/io/github/kelari/atg/listener/KelariTaskListener.java
+++ b/src/main/java/io/github/kelari/atg/listener/KelariTaskListener.java
@@ -83,7 +83,7 @@ public class KelariTaskListener implements TaskListener {
                                 trees.printMessage(kind, msg, path.getLeaf(), path.getCompilationUnit())
                         );
                         // ✨ Generate the test class file(s)
-                        kelariClassGeneration.generateTestClass();
+                        kelariClassGeneration.generateSpec();
                     }
                 }
 

--- a/src/main/java/io/github/kelari/atg/model/CaseTest.java
+++ b/src/main/java/io/github/kelari/atg/model/CaseTest.java
@@ -1,6 +1,8 @@
 package io.github.kelari.atg.model;
 
+import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.Set;
 
 public class CaseTest extends LinkedHashMap<String, CaseTest> {
 
@@ -10,7 +12,13 @@ public class CaseTest extends LinkedHashMap<String, CaseTest> {
     private int expectedStatusCode;
     private boolean requiresAuth;
     private String dataProviderClassName;
+    private int repeat;
+    private boolean enableLogging = false;
     private ParameterMetadataTest methodParameters;
+    private long responseTimeoutSeconds;
+    private Set<Header> expectedHeaders = new HashSet<>(0);
+    private Set<Cookie> expectedCookies = new HashSet<>(0);
+    private Set<JsonPath> jsonPaths = new HashSet<>(0);
 
     public String getDisplayName() {
         return displayName;
@@ -86,6 +94,71 @@ public class CaseTest extends LinkedHashMap<String, CaseTest> {
     }
     public CaseTest methodParameters(ParameterMetadataTest methodParameters) {
         this.methodParameters = methodParameters;
+        return this;
+    }
+
+    public int getRepeat() {
+        return repeat;
+    }
+    public void setRepeat(int repeat) {
+        this.repeat = repeat;
+    }
+    public CaseTest repeat(int repeat) {
+        this.repeat = repeat;
+        return this;
+    }
+
+    public boolean isEnableLogging() {
+        return enableLogging;
+    }
+    public void setEnableLogging(boolean enableLogging) {
+        this.enableLogging = enableLogging;
+    }
+    public CaseTest enableLogging(boolean enableLogging) {
+        this.enableLogging = enableLogging;
+        return this;
+    }
+
+    public long getResponseTimeoutSeconds() {
+        return responseTimeoutSeconds;
+    }
+    public void setResponseTimeoutSeconds(long responseTimeoutSeconds) {
+        this.responseTimeoutSeconds = responseTimeoutSeconds;
+    }
+    public CaseTest responseTimeoutSeconds(long responseTimeoutSeconds) {
+        this.responseTimeoutSeconds = responseTimeoutSeconds;
+        return this;
+    }
+
+    public Set<Header> getExpectedHeaders() {
+        return expectedHeaders;
+    }
+    public void setExpectedHeaders(Set<Header> expectedHeaders) {
+        this.expectedHeaders = expectedHeaders;
+    }
+    public CaseTest expectedHeaders(Header header) {
+        this.expectedHeaders.add(header);
+        return this;
+    }
+
+    public Set<Cookie> getExpectedCookies() {
+        return expectedCookies;
+    }
+    public void setExpectedCookies(Set<Cookie> expectedCookies) {
+        this.expectedCookies = expectedCookies;
+    }
+    public void expectedCookies(Cookie cookie) {
+        this.expectedCookies.add(cookie);
+    }
+
+    public Set<JsonPath> getJsonPaths() {
+        return jsonPaths;
+    }
+    public void setJsonPaths(Set<JsonPath> jsonPaths) {
+        this.jsonPaths = jsonPaths;
+    }
+    public CaseTest jsonPaths(JsonPath jsonPath) {
+        this.jsonPaths.add(jsonPath);
         return this;
     }
 }

--- a/src/main/java/io/github/kelari/atg/model/Cookie.java
+++ b/src/main/java/io/github/kelari/atg/model/Cookie.java
@@ -1,0 +1,18 @@
+package io.github.kelari.atg.model;
+
+public class Cookie {
+    private String name;
+    private String value;
+
+    public Cookie(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    public String getName() {
+        return name;
+    }
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/io/github/kelari/atg/model/Header.java
+++ b/src/main/java/io/github/kelari/atg/model/Header.java
@@ -1,0 +1,18 @@
+package io.github.kelari.atg.model;
+
+public class Header {
+    private String name;
+    private String[] values;
+
+    public Header(String name, String... values) {
+        this.name = name;
+        this.values = values;
+    }
+
+    public String getName() {
+        return name;
+    }
+    public String[] getValues() {
+        return values;
+    }
+}

--- a/src/main/java/io/github/kelari/atg/model/JsonPath.java
+++ b/src/main/java/io/github/kelari/atg/model/JsonPath.java
@@ -1,0 +1,46 @@
+package io.github.kelari.atg.model;
+
+import io.github.kelari.atg.annotation.MatcherType;
+
+public class JsonPath {
+
+    private String path;
+    private MatcherType type;
+    private String value;
+    private String matcherClass;
+
+    public JsonPath(String path, MatcherType type, String value, String matcherClass) {
+        this.path = path;
+        this.type = type;
+        this.value = value;
+        this.matcherClass = matcherClass;
+    }
+
+    public String getPath() {
+        return path;
+    }
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public MatcherType getType() {
+        return type;
+    }
+    public void setType(MatcherType type) {
+        this.type = type;
+    }
+
+    public String getValue() {
+        return value;
+    }
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public String getMatcherClass() {
+        return matcherClass;
+    }
+    public void setMatcherClass(String matcherClass) {
+        this.matcherClass = matcherClass;
+    }
+}

--- a/src/main/java/io/github/kelari/atg/process/handler/ClientNameResolver.java
+++ b/src/main/java/io/github/kelari/atg/process/handler/ClientNameResolver.java
@@ -1,0 +1,32 @@
+package io.github.kelari.atg.process.handler;
+
+import io.github.kelari.atg.model.CaseTest;
+
+/**
+ * A utility class responsible for resolving the client name based on the configuration of the {@link CaseTest}.
+ * <p>This class determines the appropriate client name to be used in the dynamically generated test methods,
+ * based on whether logging is enabled or if a response timeout is configured for the test case.</p>
+ *
+ * <p>If logging is enabled or a non-zero response timeout is specified, the client name is resolved to "client".
+ * Otherwise, it resolves to "webTestClient". This is important for determining which client instance
+ * will be used during test execution.</p>
+ *
+ * @author <a href="mailto:agsn10@hotmail.com">Antonio Neto</a>  [<()>] – Initial implementation.
+ * @since 1.0
+ * @copyright 2025 Kelari. All rights reserved.
+ * @see CaseTest
+ */
+public final class ClientNameResolver {
+
+    /**
+     * Resolves the client name based on the test case configuration.
+     *
+     * @param test the {@link CaseTest} containing the test configuration
+     * @return a {@code String} representing the resolved client name, either "client" or "webTestClient"
+     */
+    public static String resolve(CaseTest test){
+        return (test.isEnableLogging() || test.getResponseTimeoutSeconds() > 0)
+                ? "client"
+                : "webTestClient";
+    }
+}

--- a/src/main/java/io/github/kelari/atg/process/handler/FluentMethodSpecHandler.java
+++ b/src/main/java/io/github/kelari/atg/process/handler/FluentMethodSpecHandler.java
@@ -1,0 +1,47 @@
+package io.github.kelari.atg.process.handler;
+
+import io.github.kelari.atg.model.CaseTest;
+import io.github.kelari.atg.model.SpecScenariosTest;
+
+import java.util.List;
+
+/**
+ * A functional interface representing a handler that modifies a test method's statement and arguments.
+ * This handler is part of a chain that applies modifications sequentially to the test method's construction.
+ *
+ * <p>The {@link FluentMethodSpecHandler} is responsible for handling specific parts of a dynamically generated test method,
+ * such as modifying the URI, adding headers, body, cookies, or any other part of the method. The handler applies modifications
+ * by modifying the provided {@link StringBuilder} (statement) and {@link List} of arguments.</p>
+ *
+ * <p>This interface is intended to be used in conjunction with the {@link FluentMethodSpecHandlerChain}, which applies
+ * multiple handlers to generate the complete test method.</p>
+ *
+ * @author <a href="mailto:agsn10@hotmail.com">Antonio Neto</a>  [<()>] – Initial implementation.
+ * @since 1.0
+ * @copyright 2025 Kelari. All rights reserved.
+ * @see FluentMethodSpecHandlerChain
+ * @see CaseTest
+ * @see SpecScenariosTest
+ */
+@FunctionalInterface
+public interface FluentMethodSpecHandler {
+
+    /**
+     * Handles a part of the test method's statement and arguments.
+     *
+     * <p>This method is intended to apply modifications to the test method's statement and arguments,
+     * such as appending specific parts to the {@link StringBuilder} statement or adding arguments
+     * to the {@link List} args based on the provided test data and scenario.</p>
+     *
+     * @param statement a {@link StringBuilder} that accumulates the test method's statement
+     * @param args      a list of arguments that will be used within the test method's statement
+     * @param spec      the {@link SpecScenariosTest} that contains the test scenario specifications
+     * @param test      the {@link CaseTest} that contains the specific case test data
+     * @param fullPath  the full URI path of the endpoint being tested
+     */
+    void handle(StringBuilder statement,
+                List<Object> args,
+                SpecScenariosTest spec,
+                CaseTest test,
+                String fullPath);
+}

--- a/src/main/java/io/github/kelari/atg/process/handler/FluentMethodSpecHandlerChain.java
+++ b/src/main/java/io/github/kelari/atg/process/handler/FluentMethodSpecHandlerChain.java
@@ -1,0 +1,62 @@
+package io.github.kelari.atg.process.handler;
+
+import io.github.kelari.atg.model.CaseTest;
+import io.github.kelari.atg.model.SpecScenariosTest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * A helper class responsible for managing a chain of {@link FluentMethodSpecHandler} instances.
+ * This class follows the Chain of Responsibility design pattern to apply multiple handlers sequentially
+ * to modify a {@link StringBuilder} and a list of arguments, ultimately building a dynamic test method.
+ *
+ * <p>Each {@link FluentMethodSpecHandler} is responsible for handling a specific part of the test method,
+ * such as URI, headers, body, cookies, etc. The {@link FluentMethodSpecHandlerChain} allows these handlers
+ * to be applied in sequence to modify the test method construction process dynamically.</p>
+ *
+ * @author <a href="mailto:agsn10@hotmail.com">Antonio Neto</a>  [<()>] – Initial implementation.
+ * @since 1.0
+ * @copyright 2025 Kelari. All rights reserved.
+ * @see FluentMethodSpecHandler
+ * @see CaseTest
+ * @see SpecScenariosTest
+ */
+public class FluentMethodSpecHandlerChain {
+    private final List<FluentMethodSpecHandler> handlers = new ArrayList<>();
+
+    /**
+     * Adds a {@link FluentMethodSpecHandler} to the chain.
+     *
+     * @param supplier a supplier that provides an instance of the {@link FluentMethodSpecHandler} to be added
+     * @return the current instance of {@link FluentMethodSpecHandlerChain} for method chaining
+     */
+    public FluentMethodSpecHandlerChain add(Supplier<FluentMethodSpecHandler> supplier) {
+        handlers.add(supplier.get());
+        return this;
+    }
+
+    /**
+     * Applies all handlers in the chain to modify the provided {@link StringBuilder} and list of arguments
+     * based on the test scenario and case test data.
+     *
+     * <p>This method iterates over all handlers in the chain and calls their {@link FluentMethodSpecHandler#handle}
+     * method to apply modifications to the statement and arguments.</p>
+     *
+     * @param statement a {@link StringBuilder} that accumulates the test method's statement
+     * @param args      a list of arguments that will be used within the test method's statement
+     * @param spec      the {@link SpecScenariosTest} that contains the test scenario specifications
+     * @param test      the {@link CaseTest} that contains the specific case test data
+     * @param fullPath  the full URI path of the endpoint being tested
+     */
+    public void applyAll(StringBuilder statement,
+                         List<Object> args,
+                         SpecScenariosTest spec,
+                         CaseTest test,
+                         String fullPath) {
+        for (FluentMethodSpecHandler handler : handlers) {
+            handler.handle(statement, args, spec, test, fullPath);
+        }
+    }
+}

--- a/src/main/java/io/github/kelari/atg/process/handler/MethodSpecHandler.java
+++ b/src/main/java/io/github/kelari/atg/process/handler/MethodSpecHandler.java
@@ -1,0 +1,41 @@
+package io.github.kelari.atg.process.handler;
+
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.MethodSpec;
+import io.github.kelari.atg.model.CaseTest;
+import io.github.kelari.atg.model.SpecScenariosTest;
+
+/**
+ * A functional interface for handlers that modify a {@link MethodSpec} used to dynamically generate and modify
+ * test methods. Each implementation of {@link MethodSpecHandler} is responsible for applying modifications to
+ * the test method (such as adding annotations, generating code, or configuring parameters) based on the data
+ * provided in a {@link SpecScenariosTest} and a {@link CaseTest}.
+ *
+ * <p>This interface allows the use of the Chain of Responsibility design pattern, where multiple handlers
+ * can be applied sequentially to configure the test method as needed.</p>
+ *
+
+ * @author <a href="mailto:agsn10@hotmail.com">Antonio Neto</a>  [<()>] – Initial implementation.
+ * @since 1.0
+ * @see MethodSpec
+ * @see SpecScenariosTest
+ * @see CaseTest
+ * @copyright 2025 Kelari. All rights reserved.
+ */
+@FunctionalInterface
+public interface MethodSpecHandler {
+
+    /**
+     * Responsible for modifying the {@link MethodSpec.Builder} and {@link CodeBlock.Builder}
+     * based on the provided test scenario specifications and case test data.
+     * This method is called within a workflow where multiple handlers can be applied
+     * sequentially to dynamically configure the test method.
+     *
+     * @param methodBuilder     the {@link MethodSpec.Builder} used to construct the test method.
+     * @param codeBlockBuilder  the {@link CodeBlock.Builder} used to construct the method body.
+     * @param spec              the {@link SpecScenariosTest} that contains the test scenario specifications.
+     * @param test              the {@link CaseTest} that contains the specific case test data.
+     * @param fullPath          the full URI path of the endpoint being tested.
+     */
+    void handle(MethodSpec.Builder methodBuilder, CodeBlock.Builder codeBlockBuilder, SpecScenariosTest spec, CaseTest test, String fullPath);
+}

--- a/src/main/java/io/github/kelari/atg/process/handler/MethodSpecHandlerChain.java
+++ b/src/main/java/io/github/kelari/atg/process/handler/MethodSpecHandlerChain.java
@@ -1,0 +1,58 @@
+package io.github.kelari.atg.process.handler;
+
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.MethodSpec;
+import io.github.kelari.atg.model.CaseTest;
+import io.github.kelari.atg.model.SpecScenariosTest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * A helper class that manages a chain of {@link MethodSpecHandler} instances.
+ * This class allows the dynamic construction of a chain of handlers that modify a {@link MethodSpec}
+ * and a {@link CodeBlock} based on various conditions in the provided {@link SpecScenariosTest} and {@link CaseTest}.
+ * The handlers are applied in the order they are added to the chain.
+ *
+ * <p>The {@link MethodSpecHandlerChain} class is used to apply various configurations to a test method,
+ * such as annotations, parameters, and any necessary setup or teardown operations.</p>
+ *
+ * @author <a href="mailto:agsn10@hotmail.com">Antonio Neto</a>  [<()>] – Initial implementation.
+ * @since 1.0
+ * @see MethodSpecHandler
+ * @copyright 2025 Kelari. All rights reserved.
+ */
+public class MethodSpecHandlerChain {
+
+    private final List<MethodSpecHandler> handlers = new ArrayList<>();
+
+    /**
+     * Adds a new {@link MethodSpecHandler} to the handler chain.
+     *
+     * @param supplier a {@link Supplier} that provides an instance of the {@link MethodSpecHandler}.
+     * @return the current {@link MethodSpecHandlerChain} instance for method chaining.
+     */
+    public MethodSpecHandlerChain add(Supplier<MethodSpecHandler> supplier) {
+        handlers.add(supplier.get());
+        return this;
+    }
+
+    /**
+     * Applies all the handlers in the chain to the provided {@link MethodSpec.Builder} and {@link CodeBlock.Builder}.
+     * Each handler in the chain is responsible for modifying the method spec and code block according to the test scenario.
+     *
+     * <p>Handlers might add annotations, generate code, or configure other aspects of the test method.</p>
+     *
+     * @param methodBuilder   the {@link MethodSpec.Builder} representing the test method being built.
+     * @param codeBlockBuilder the {@link CodeBlock.Builder} used to build the body of the method.
+     * @param spec            the {@link SpecScenariosTest} containing the test specifications.
+     * @param test            the {@link CaseTest} containing the specific test case data.
+     * @param fullPath        the full URI path of the endpoint being tested.
+     */
+    public void applyAll(MethodSpec.Builder methodBuilder, CodeBlock.Builder codeBlockBuilder, SpecScenariosTest spec, CaseTest test, String fullPath) {
+        for (MethodSpecHandler handler : handlers) {
+            handler.handle(methodBuilder, codeBlockBuilder, spec, test, fullPath);
+        }
+    }
+}

--- a/src/main/java/io/github/kelari/atg/process/handler/annotations/DisplayNameHandler.java
+++ b/src/main/java/io/github/kelari/atg/process/handler/annotations/DisplayNameHandler.java
@@ -1,0 +1,55 @@
+package io.github.kelari.atg.process.handler.annotations;
+
+import com.squareup.javapoet.AnnotationSpec;
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.MethodSpec;
+import io.github.kelari.atg.model.CaseTest;
+import io.github.kelari.atg.model.SpecScenariosTest;
+import io.github.kelari.atg.process.handler.MethodSpecHandler;
+import io.github.kelari.atg.util.Constants;
+
+import java.util.Objects;
+
+/**
+ * {@code DisplayNameHandler} is a {@link MethodSpecHandler} implementation responsible
+ * for adding the {@code @DisplayName} annotation to the generated test method.
+ *
+ * <p>This annotation improves test readability by providing a human-friendly description
+ * that appears in test reports and IDE test runners.
+ *
+ * <p>The display name value is taken from the {@code displayName} property of the {@link CaseTest}.
+ *
+ * <p>Example generated output:
+ * <pre>{@code
+ * @DisplayName("✅ Should return 200 OK when the ID is valid")
+ * }</pre>
+ *
+ * @author <a href="mailto:agsn10@hotmail.com">Antonio Neto</a> [<()>] – Initial implementation.
+ * @since 1.0
+ * @copyright 2025 Kelari. All rights reserved.
+ */
+public class DisplayNameHandler implements MethodSpecHandler {
+
+    /**
+     * Adds the {@code @DisplayName} annotation to the test method, if the
+     * {@code displayName} field is defined in the {@link CaseTest}.
+     *
+     * @param builder           the method builder to which the annotation will be added
+     * @param codeBlockBuilder the code block builder for the method body (not used here)
+     * @param spec              the test scenario specification (not used here)
+     * @param test              the test case containing the display name
+     * @param fullPath          the full request path (not used here)
+     */
+    @Override
+    public void handle(MethodSpec.Builder builder,
+                       CodeBlock.Builder codeBlockBuilder,
+                       SpecScenariosTest spec,
+                       CaseTest test,
+                       String fullPath) {
+        if (Objects.nonNull(test.getDisplayName()) && !test.getDisplayName().isEmpty()) {
+            builder.addAnnotation(AnnotationSpec.builder(Constants.Imports.DISPLAY_NAME)
+                    .addMember("value", "$S", test.getDisplayName())
+                    .build());
+        }
+    }
+}

--- a/src/main/java/io/github/kelari/atg/process/handler/annotations/OrderHandler.java
+++ b/src/main/java/io/github/kelari/atg/process/handler/annotations/OrderHandler.java
@@ -1,0 +1,56 @@
+package io.github.kelari.atg.process.handler.annotations;
+
+import com.squareup.javapoet.AnnotationSpec;
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.MethodSpec;
+import io.github.kelari.atg.model.CaseTest;
+import io.github.kelari.atg.model.SpecScenariosTest;
+import io.github.kelari.atg.process.handler.MethodSpecHandler;
+import io.github.kelari.atg.util.Constants;
+
+/**
+ * {@code OrderHandler} is a {@link MethodSpecHandler} implementation that adds the {@code @Order}
+ * annotation to the generated test method.
+ * <p>
+ * The {@code @Order} annotation defines the execution order of test methods in a test class.
+ * It is useful for ensuring that some tests are run before others, especially in integration testing.
+ * <p>
+ * The order value is retrieved from the {@code timeout} field in the {@link CaseTest}.
+ * This may be a mistake; logically, the value should come from an {@code order} field.
+ * If this is intentional, consider renaming the field or updating the logic.
+ *
+ * <p>Example generated output:
+ * <pre>{@code
+ * @Order(3)
+ * }</pre>
+ *
+ * @author <a href="mailto:agsn10@hotmail.com">Antonio Neto</a> [<()>] – Initial implementation.
+ * @since 1.0
+ * @copyright 2025 Kelari. All rights reserved.
+ */
+public class OrderHandler implements MethodSpecHandler {
+
+    /**
+     * Adds the {@code @Order} annotation to the test method if the timeout value in {@link CaseTest}
+     * is greater than zero. Note that it currently uses {@code getTimeout()} as the source for the order,
+     * which may require clarification or adjustment.
+     *
+     * @param builder           the method builder to which the annotation will be added
+     * @param codeBlockBuilder the code block builder for the method body (not used here)
+     * @param spec              the test scenario specification (not used here)
+     * @param test              the test case containing the timeout (used as order)
+     * @param fullPath          the full request path (not used here)
+     */
+    @Override
+    public void handle(MethodSpec.Builder builder,
+                       CodeBlock.Builder codeBlockBuilder,
+                       SpecScenariosTest spec,
+                       CaseTest test,
+                       String fullPath) {
+        if (test.getTimeout() > 0) {
+            builder.addAnnotation(AnnotationSpec.builder(Constants.Imports.ORDER)
+                    .addMember("value", "$L", test.getOrder())
+                    .build());
+        }
+    }
+}

--- a/src/main/java/io/github/kelari/atg/process/handler/annotations/RepeatHandler.java
+++ b/src/main/java/io/github/kelari/atg/process/handler/annotations/RepeatHandler.java
@@ -1,0 +1,60 @@
+package io.github.kelari.atg.process.handler.annotations;
+
+import com.squareup.javapoet.AnnotationSpec;
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.MethodSpec;
+import io.github.kelari.atg.model.CaseTest;
+import io.github.kelari.atg.model.SpecScenariosTest;
+import io.github.kelari.atg.process.handler.MethodSpecHandler;
+import io.github.kelari.atg.util.Constants;
+
+/**
+ * {@code RepeatHandler} is a {@link MethodSpecHandler} implementation that adds the {@code @Repeat}
+ * annotation to the generated test method if the {@link CaseTest#getRepeat()} value is greater than 1.
+ * <p>
+ * The {@code @Repeat} annotation is used to repeat the execution of a test method multiple times. If
+ * the {@code repeat} field in {@link CaseTest} is 1 or less, the method is annotated with {@code @Test}
+ * instead, ensuring that only the specified number of repetitions occurs.
+ * <p>
+ * Example generated output when {@code repeat} is greater than 1:
+ * <pre>{@code
+ * @Repeat(5)
+ * }</pre>
+ *
+ * <p>When the repeat count is 1 or less, the default {@code @Test} annotation will be used instead:
+ * <pre>{@code
+ * @Test
+ * }</pre>
+ *
+ * @author <a href="mailto:agsn10@hotmail.com">Antonio Neto</a> [<()>] – Initial implementation.
+ * @since 1.0
+ * @copyright 2025 Kelari. All rights reserved.
+ */
+public class RepeatHandler implements MethodSpecHandler {
+
+    /**
+     * Adds the {@code @Repeat} annotation to the test method if the {@code repeat} value in
+     * {@link CaseTest} is greater than 1. If {@code repeat} is 1 or less, the method is annotated
+     * with {@code @Test} instead.
+     *
+     * @param builder           the method builder to which the annotation will be added
+     * @param codeBlockBuilder the code block builder for the method body (not used here)
+     * @param spec              the test scenario specification (not used here)
+     * @param test              the test case containing the repeat count
+     * @param fullPath          the full request path (not used here)
+     */
+    @Override
+    public void handle(MethodSpec.Builder builder,
+                       CodeBlock.Builder codeBlockBuilder,
+                       SpecScenariosTest spec,
+                       CaseTest test,
+                       String fullPath) {
+        if (test.getRepeat() > 1) {
+            builder.addAnnotation(AnnotationSpec.builder(Constants.Imports.REPEAT)
+                    .addMember("value", "$L", test.getRepeat())
+                    .build());
+        } else {
+            builder.addAnnotation(Constants.Imports.TEST);
+        }
+    }
+}

--- a/src/main/java/io/github/kelari/atg/process/handler/annotations/TimeoutHandler.java
+++ b/src/main/java/io/github/kelari/atg/process/handler/annotations/TimeoutHandler.java
@@ -1,0 +1,54 @@
+package io.github.kelari.atg.process.handler.annotations;
+
+import com.squareup.javapoet.AnnotationSpec;
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.MethodSpec;
+import io.github.kelari.atg.model.CaseTest;
+import io.github.kelari.atg.model.SpecScenariosTest;
+import io.github.kelari.atg.process.handler.MethodSpecHandler;
+import io.github.kelari.atg.util.Constants;
+
+/**
+ * {@code TimeoutHandler} is a {@link MethodSpecHandler} implementation that adds the {@code @Timeout}
+ * annotation to the generated test method if the {@link CaseTest#getTimeout()} value is greater than 0.
+ * <p>
+ * The {@code @Timeout} annotation is used to specify the maximum duration allowed for a test method
+ * to run. If the {@code timeout} field in {@link CaseTest} is greater than 0, the method is annotated
+ * with {@code @Timeout}. Otherwise, the test method will not have a timeout annotation.
+ * <p>
+ * Example generated output when {@code timeout} is greater than 0:
+ * <pre>{@code
+ * @Timeout(5000) // Timeout of 5000 milliseconds
+ * }</pre>
+ *
+ * <p>If the {@code timeout} value is 0 or less, no annotation is added to the test method.
+ *
+ * @author <a href="mailto:agsn10@hotmail.com">Antonio Neto</a> [<()>] – Initial implementation.
+ * @since 1.0
+ * @copyright 2025 Kelari. All rights reserved.
+ */
+public class TimeoutHandler implements MethodSpecHandler {
+
+    /**
+     * Adds the {@code @Timeout} annotation to the test method if the {@code timeout} value in
+     * {@link CaseTest} is greater than 0.
+     *
+     * @param builder           the method builder to which the annotation will be added
+     * @param codeBlockBuilder the code block builder for the method body (not used here)
+     * @param spec              the test scenario specification (not used here)
+     * @param test              the test case containing the timeout value
+     * @param fullPath          the full request path (not used here)
+     */
+    @Override
+    public void handle(MethodSpec.Builder builder,
+                       CodeBlock.Builder codeBlockBuilder,
+                       SpecScenariosTest spec,
+                       CaseTest test,
+                       String fullPath) {
+        if (test.getTimeout() > 0) {
+            builder.addAnnotation(AnnotationSpec.builder(Constants.Imports.TIMEOUT)
+                    .addMember("value", "$L", test.getTimeout())
+                    .build());
+        }
+    }
+}

--- a/src/main/java/io/github/kelari/atg/process/handler/client/AuthHandler.java
+++ b/src/main/java/io/github/kelari/atg/process/handler/client/AuthHandler.java
@@ -1,0 +1,54 @@
+package io.github.kelari.atg.process.handler.client;
+
+import io.github.kelari.atg.model.CaseTest;
+import io.github.kelari.atg.model.SpecScenariosTest;
+import io.github.kelari.atg.process.handler.FluentMethodSpecHandler;
+
+import java.util.List;
+
+/**
+ * {@code AuthHandler} is an implementation of {@link FluentMethodSpecHandler} that adds the
+ * {@code Authorization} header to the HTTP request if the test case requires authentication.
+ * <p>
+ * This handler checks if the test case {@link CaseTest#isRequiresAuth()} is {@code true}, and if so,
+ * it appends an authorization header with a "bearer" token to the HTTP request. The token value
+ * used in this case is a placeholder string {@code "bearerToken"}.
+ * </p>
+ * Example generated output when authentication is required:
+ * <pre>{@code
+ * .header("Authorization", "bearerToken")
+ * }</pre>
+ * <p>
+ * If the test case does not require authentication, this handler does nothing.
+ * </p>
+ *
+ * @author <a href="mailto:agsn10@hotmail.com">Antonio Neto</a> [<()>] – Initial implementation.
+ * @since 1.0
+ * @copyright 2025 Kelari. All rights reserved.
+ */
+public class AuthHandler implements FluentMethodSpecHandler {
+
+    /**
+     * Adds the {@code Authorization} header with a bearer token to the HTTP request
+     * if authentication is required by the test case.
+     *
+     * @param statement the statement being constructed for the HTTP request
+     * @param args      the arguments to be inserted into the statement
+     * @param spec      the specification for the test scenario
+     * @param test      the individual test case
+     * @param fullPath  the full path of the test (not used here)
+     */
+    @Override
+    public void handle(StringBuilder statement,
+                       List<Object> args,
+                       SpecScenariosTest spec,
+                       CaseTest test,
+                       String fullPath) {
+
+        if (test.isRequiresAuth()) {
+            statement.append("\n\t.header($S, $L)");
+            args.add("Authorization");
+            args.add("bearerToken");
+        }
+    }
+}

--- a/src/main/java/io/github/kelari/atg/process/handler/client/BodyHandler.java
+++ b/src/main/java/io/github/kelari/atg/process/handler/client/BodyHandler.java
@@ -1,0 +1,88 @@
+package io.github.kelari.atg.process.handler.client;
+
+import io.github.kelari.atg.model.CaseTest;
+import io.github.kelari.atg.model.ParameterMetadataTest;
+import io.github.kelari.atg.model.SpecScenariosTest;
+import io.github.kelari.atg.process.handler.FluentMethodSpecHandler;
+import io.github.kelari.atg.process.helper.MethodGenerationHelper;
+import io.github.kelari.atg.util.Constants;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * {@code BodyHandler} is an implementation of {@link FluentMethodSpecHandler} that manages the
+ * body content and content type of an HTTP request based on the method and parameters.
+ * <p>
+ * This handler generates the appropriate body and content type for the HTTP request.
+ * It checks the HTTP method type and handles scenarios where the body of the request is required.
+ * It also handles multipart form data and JSON bodies, depending on the method and parameters.
+ * </p>
+ * <p>
+ * For multipart form data, it adds the {@code contentType} as {@code MULTIPART_FORM_DATA} and uses
+ * a method to build the multipart data.
+ * </p>
+ * <p>
+ * For JSON bodies, it sets the {@code contentType} as {@code APPLICATION_JSON} and includes the
+ * body values from the test parameters.
+ * </p>
+ * <p>
+ * Example generated output for multipart form data:
+ * <pre>{@code
+ * .contentType(MediaType.MULTIPART_FORM_DATA)
+ * .body(BodyInserters.fromMultipartData(buildMultipartData(data)))
+ * }</pre>
+ * Example generated output for JSON body:
+ * <pre>{@code
+ * .contentType(MediaType.APPLICATION_JSON)
+ * .bodyValue(formatBody(entry.getKey()))
+ * }</pre>
+ * </p>
+ *
+ * @author <a href="mailto:agsn10@hotmail.com">Antonio Neto</a> [<()>] – Initial implementation.
+ * @since 1.0
+ * @copyright 2025 Kelari. All rights reserved.
+ */
+public class BodyHandler implements FluentMethodSpecHandler {
+
+    /**
+     * Handles the body content and content type for the HTTP request based on the method type and parameters.
+     * It adds the necessary content type and body values to the statement depending on the HTTP method
+     * (e.g., multipart form data or JSON body).
+     *
+     * @param statement the statement being constructed for the HTTP request
+     * @param args      the arguments to be inserted into the statement
+     * @param spec      the specification for the test scenario
+     * @param test      the individual test case
+     * @param fullPath  the full path of the test (not used here)
+     */
+    @Override
+    public void handle(StringBuilder statement,
+                       List<Object> args,
+                       SpecScenariosTest spec,
+                       CaseTest test,
+                       String fullPath) {
+
+        String httpMethod = spec.getHttpMethod().toLowerCase();
+
+        if (MethodGenerationHelper.requiresMultipartFormData(httpMethod, test.getMethodParameters())) {
+            statement.append("\n\t.contentType($T.MULTIPART_FORM_DATA)");
+            args.add(Constants.Imports.MEDIA_TYPE);
+            statement.append("\n\t.body($T.fromMultipartData(buildMultipartData(data)))");
+            args.add(Constants.Imports.BODY_INSERTERS);
+        } else if (MethodGenerationHelper.requiresBody(httpMethod)) {
+            statement.append("\n\t.contentType($T.APPLICATION_JSON)");
+            args.add(Constants.Imports.MEDIA_TYPE);
+
+            Optional.ofNullable(test.getMethodParameters())
+                    .map(ParameterMetadataTest::getBody)
+                    .ifPresent(bodyMap -> {
+                        for (Map.Entry<String, String> entry : bodyMap.entrySet()) {
+                            statement.append("\n\t.bodyValue(formatBody($L))");
+                            args.add(entry.getKey());
+                        }
+                    });
+        }
+    }
+}

--- a/src/main/java/io/github/kelari/atg/process/handler/client/ClientInitializationHandler.java
+++ b/src/main/java/io/github/kelari/atg/process/handler/client/ClientInitializationHandler.java
@@ -1,0 +1,68 @@
+package io.github.kelari.atg.process.handler.client;
+
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.MethodSpec;
+import io.github.kelari.atg.model.CaseTest;
+import io.github.kelari.atg.model.SpecScenariosTest;
+import io.github.kelari.atg.process.handler.MethodSpecHandler;
+import io.github.kelari.atg.util.Constants;
+
+/**
+ * {@code ClientInitializationHandler} is an implementation of {@link MethodSpecHandler} that is responsible for
+ * initializing the {@link WebTestClient} based on test-specific configurations, such as logging filters and response
+ * timeouts.
+ * <p>
+ * This handler checks the test case configurations for enabling logging and setting response timeouts. If logging is enabled,
+ * it adds filters for logging the request and response. If a response timeout is specified, it adds the corresponding timeout configuration.
+ * </p>
+ * <p>
+ * Example generated output:
+ * <pre>{@code
+ * this.webTestClient
+ *     .mutate()
+ *     .filter(logRequest())
+ *     .filter(logResponse())
+ *     .responseTimeout(Duration.ofSeconds(5))
+ *     .build();
+ * }</pre>
+ * </p>
+ *
+ * @author <a href="mailto:agsn10@hotmail.com">Antonio Neto</a> [<()>] – Initial implementation.
+ * @since 1.0
+ * @copyright 2025 Kelari. All rights reserved.
+ */
+public class ClientInitializationHandler implements MethodSpecHandler {
+
+    /**
+     * Handles the initialization of the {@link WebTestClient} by adding the necessary configurations based on the test case settings.
+     * It adds filters for logging the request and response, as well as setting the response timeout if configured.
+     *
+     * @param builder            the builder used to construct the method specification
+     * @param codeBlockBuilder   the builder used to generate the code block for the client initialization
+     * @param spec               the specification for the test scenario
+     * @param test               the individual test case containing test-specific configurations
+     * @param fullPath           the full path of the test (not used here)
+     */
+    @Override
+    public void handle(MethodSpec.Builder builder,
+                       CodeBlock.Builder codeBlockBuilder,
+                       SpecScenariosTest spec,
+                       CaseTest test,
+                       String fullPath) {
+        if (test.isEnableLogging() || test.getResponseTimeoutSeconds() > 0) {
+            CodeBlock.Builder clientBuilder = CodeBlock.builder();
+            clientBuilder.add("this.webTestClient\n\t.mutate()");
+            if (test.isEnableLogging()) {
+                clientBuilder.add("\n\t.filter(logRequest())")
+                        .add("\n\t.filter(logResponse())");
+            }
+            if (test.getResponseTimeoutSeconds() > 0) {
+                clientBuilder.add("\n\t.responseTimeout($T.ofSeconds($L))",
+                        Constants.Imports.DURATION, test.getResponseTimeoutSeconds());
+            }
+            clientBuilder.add("\n\t.build()");
+            codeBlockBuilder.addStatement("$T client = $L",
+                    Constants.Imports.WEB_TEST_CLIENT, clientBuilder.build());
+        }
+    }
+}

--- a/src/main/java/io/github/kelari/atg/process/handler/client/CookieHandler.java
+++ b/src/main/java/io/github/kelari/atg/process/handler/client/CookieHandler.java
@@ -1,0 +1,58 @@
+package io.github.kelari.atg.process.handler.client;
+
+import io.github.kelari.atg.model.CaseTest;
+import io.github.kelari.atg.model.ParameterMetadataTest;
+import io.github.kelari.atg.model.SpecScenariosTest;
+import io.github.kelari.atg.process.handler.FluentMethodSpecHandler;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * {@code CookieHandler} is an implementation of {@link FluentMethodSpecHandler} responsible for handling cookie parameters
+ * in API test cases. It processes the cookie parameters from the test's method metadata and appends the appropriate statements
+ * to the generated test code.
+ * <p>
+ * This handler will extract the cookie parameters from the test case's method metadata and construct statements to include
+ * cookies in the WebTestClient request.
+ * </p>
+ * <p>
+ * Example generated output:
+ * <pre>{@code
+ * .cookie("cookieName", safeString(data.get("cookieName")))
+ * }</pre>
+ * </p>
+ *
+ * @author <a href="mailto:agsn10@hotmail.com">Antonio Neto</a> [<()>] – Initial implementation.
+ * @since 1.0
+ * @copyright 2025 Kelari. All rights reserved.
+ */
+public class CookieHandler implements FluentMethodSpecHandler {
+
+    /**
+     * Handles the inclusion of cookies in the WebTestClient request by processing the cookie parameters defined in the test case.
+     * For each cookie parameter, a statement is generated to add it to the WebTestClient request.
+     *
+     * @param statement the StringBuilder used to append the generated statements
+     * @param args      the list of arguments for the generated statements
+     * @param spec      the specification for the test scenario
+     * @param test      the individual test case containing the method parameters with cookie information
+     * @param fullPath  the full path of the test (not used here)
+     */
+    @Override
+    public void handle(StringBuilder statement,
+                       List<Object> args,
+                       SpecScenariosTest spec,
+                       CaseTest test,
+                       String fullPath) {
+        Optional.ofNullable(test.getMethodParameters())
+                .map(ParameterMetadataTest::getCookieParams)
+                .ifPresent(params -> {
+                    for (String key : params.keySet()) {
+                        statement.append("\n\t.cookie($S, safeString(data.get($S)))");
+                        args.add(key);
+                        args.add(key);
+                    }
+                });
+    }
+}

--- a/src/main/java/io/github/kelari/atg/process/handler/client/DataLoadHandler.java
+++ b/src/main/java/io/github/kelari/atg/process/handler/client/DataLoadHandler.java
@@ -1,0 +1,70 @@
+package io.github.kelari.atg.process.handler.client;
+
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.MethodSpec;
+import io.github.kelari.atg.model.CaseTest;
+import io.github.kelari.atg.model.ParameterMetadataTest;
+import io.github.kelari.atg.model.SpecScenariosTest;
+import io.github.kelari.atg.process.handler.MethodSpecHandler;
+import io.github.kelari.atg.process.helper.MethodGenerationHelper;
+import io.github.kelari.atg.util.Constants;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * {@code DataLoadHandler} is an implementation of {@link MethodSpecHandler} responsible for loading data from a specified
+ * data provider class and assigning values from the data to the test case's method parameters.
+ * <p>
+ * This handler processes the data for each test case by retrieving it from the data provider class,
+ * and then assigns the corresponding values to the method parameters for API request handling.
+ * </p>
+ * <p>
+ * The handler supports body parameters that are passed as part of the request, ensuring that the necessary data is available
+ * for the HTTP request in the generated test code.
+ * </p>
+ *
+ * @author <a href="mailto:agsn10@hotmail.com">Antonio Neto</a> [<()>] – Initial implementation.
+ * @since 1.0
+ * @copyright 2025 Kelari. All rights reserved.
+ */
+public class DataLoadHandler implements MethodSpecHandler {
+
+    /**
+     * Handles the data loading process by retrieving data from the specified data provider class and assigning it to the
+     * appropriate test method parameters.
+     *
+     * @param builder            the {@link MethodSpec.Builder} used to build the test method
+     * @param codeBlockBuilder   the {@link CodeBlock.Builder} used to add the generated code blocks
+     * @param spec               the specification for the test scenario
+     * @param test               the individual test case containing method parameters and data provider class information
+     * @param fullPath           the full path of the test (not used here)
+     */
+    @Override
+    public void handle(MethodSpec.Builder builder,
+                       CodeBlock.Builder codeBlockBuilder,
+                       SpecScenariosTest spec,
+                       CaseTest test,
+                       String fullPath) {
+        codeBlockBuilder.addStatement(
+                "$T<String, Object> data = getData($S)",
+                Constants.Imports.MAP,
+                test.getDataProviderClassName()
+        );
+        String httpMethod = spec.getHttpMethod().toLowerCase();
+        Optional.ofNullable(test.getMethodParameters())
+                .map(ParameterMetadataTest::getBody)
+                .ifPresent(bodyMap -> {
+                    if (MethodGenerationHelper.requiresBody(httpMethod)
+                            && !MethodGenerationHelper.requiresMultipartFormData(httpMethod, test.getMethodParameters())) {
+                        for (Map.Entry<String, String> entry : bodyMap.entrySet()) {
+                            // Assign the body values to the method parameters
+                            codeBlockBuilder.addStatement(
+                                    "$L $L = ($L) data.get($S)",
+                                    entry.getValue(), entry.getKey(), entry.getValue(), entry.getKey()
+                            );
+                        }
+                    }
+                });
+    }
+}

--- a/src/main/java/io/github/kelari/atg/process/handler/client/ExchangeHandler.java
+++ b/src/main/java/io/github/kelari/atg/process/handler/client/ExchangeHandler.java
@@ -1,0 +1,65 @@
+package io.github.kelari.atg.process.handler.client;
+
+import io.github.kelari.atg.model.CaseTest;
+import io.github.kelari.atg.model.SpecScenariosTest;
+import io.github.kelari.atg.process.handler.FluentMethodSpecHandler;
+
+import java.util.List;
+
+/**
+ * {@code ExchangeHandler} is an implementation of {@link FluentMethodSpecHandler} responsible for handling the HTTP
+ * exchange statement and the expected status code in a test scenario.
+ * <p>
+ * This handler processes the expected HTTP status code for the given test case and generates the corresponding
+ * code for the WebTestClient's `exchange()` method, which performs the HTTP request and asserts the status code.
+ * </p>
+ * <p>
+ * The {@code expectMethod} can be configured to use different expectation types such as "DEFAULT" or others.
+ * If the {@code expectMethod} is set to "DEFAULT", the handler will add the expected status code to the statement.
+ * </p>
+ *
+ * @author <a href="mailto:agsn10@hotmail.com">Antonio Neto</a> [<()>] – Initial implementation.
+ * @since 1.0
+ * @copyright 2025 Kelari. All rights reserved.
+ */
+public class ExchangeHandler implements FluentMethodSpecHandler {
+
+    private String expectMethod;
+
+    /**
+     * Constructor for the {@code ExchangeHandler} that sets the expectation method for the status code.
+     *
+     * @param expectMethod the expectation method (e.g., "DEFAULT" or others) used to assert the expected status code
+     */
+    public ExchangeHandler(String expectMethod) {
+        this.expectMethod = expectMethod;
+    }
+
+    /**
+     * Handles the creation of the HTTP exchange statement for the test, asserting the expected status code.
+     * This method generates the code for WebTestClient's {@code exchange()} method with an expected status code check.
+     *
+     * @param statement         the {@link StringBuilder} used to build the generated test code
+     * @param args             the list of arguments that are added to the statement (e.g., status code, methods)
+     * @param spec             the specification for the test scenario
+     * @param test             the individual test case containing the expected status code
+     * @param fullPath         the full path of the test (not used here)
+     */
+    @Override
+    public void handle(StringBuilder statement,
+                       List<Object> args,
+                       SpecScenariosTest spec,
+                       CaseTest test,
+                       String fullPath) {
+
+        int statusCode = test.getExpectedStatusCode();
+        statement.append("\n\t.exchange()\n\t.expectStatus().$L");
+        args.add(this.expectMethod);
+        if ("DEFAULT".equals(this.expectMethod)) {
+            statement.append("($L)");
+            args.add(statusCode);
+        } else {
+            statement.append("()");
+        }
+    }
+}

--- a/src/main/java/io/github/kelari/atg/process/handler/client/HeaderHandler.java
+++ b/src/main/java/io/github/kelari/atg/process/handler/client/HeaderHandler.java
@@ -1,0 +1,59 @@
+package io.github.kelari.atg.process.handler.client;
+
+import io.github.kelari.atg.model.CaseTest;
+import io.github.kelari.atg.model.ParameterMetadataTest;
+import io.github.kelari.atg.model.SpecScenariosTest;
+import io.github.kelari.atg.process.handler.FluentMethodSpecHandler;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * {@code HeaderHandler} is an implementation of {@link FluentMethodSpecHandler} responsible for handling HTTP
+ * headers in a test scenario. This handler processes the headers specified in the {@code CaseTest} and generates
+ * the corresponding code to add HTTP headers to the WebTestClient request.
+ * <p>
+ * It checks the provided test case for any header parameters and generates a statement to set the headers
+ * using the WebTestClient's {@code header()} method. Each header key and value is taken from the test data.
+ * </p>
+ * <p>
+ * The generated code adds headers to the request with the format: {@code header(key, value)}.
+ * </p>
+ *
+ * @author <a href="mailto:agsn10@hotmail.com">Antonio Neto</a> [<()>] – Initial implementation.
+ * @since 1.0
+ * @copyright 2025 Kelari. All rights reserved.
+ */
+public class HeaderHandler implements FluentMethodSpecHandler {
+
+    /**
+     * Handles the generation of the HTTP header statement for the test, adding the necessary headers to the request.
+     * This method retrieves the header parameters from the {@code CaseTest} and generates the code to add those
+     * headers to the WebTestClient request.
+     *
+     * @param statement         the {@link StringBuilder} used to build the generated test code
+     * @param args             the list of arguments that are added to the statement (e.g., header key-value pairs)
+     * @param spec             the specification for the test scenario
+     * @param test             the individual test case containing the header parameters
+     * @param fullPath         the full path of the test (not used here)
+     */
+    @Override
+    public void handle(StringBuilder statement,
+                       List<Object> args,
+                       SpecScenariosTest spec,
+                       CaseTest test,
+                       String fullPath) {
+
+        // Check for header parameters in the test case
+        Optional.ofNullable(test.getMethodParameters())
+                .map(ParameterMetadataTest::getHeaderParams)
+                .ifPresent(params -> {
+                    // Iterate through the header parameters and generate header statements
+                    for (String key : params.keySet()) {
+                        statement.append("\n\t.header($S, safeString(data.get($S)))");
+                        args.add(key);
+                        args.add(key);
+                    }
+                });
+    }
+}

--- a/src/main/java/io/github/kelari/atg/process/handler/client/UriHandler.java
+++ b/src/main/java/io/github/kelari/atg/process/handler/client/UriHandler.java
@@ -1,0 +1,54 @@
+package io.github.kelari.atg.process.handler.client;
+
+import io.github.kelari.atg.model.CaseTest;
+import io.github.kelari.atg.model.ParameterMetadataTest;
+import io.github.kelari.atg.model.SpecScenariosTest;
+import io.github.kelari.atg.process.handler.FluentMethodSpecHandler;
+import io.github.kelari.atg.process.helper.MethodGenerationHelper;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * {@code UriHandler} is an implementation of {@link FluentMethodSpecHandler} that handles the generation of the
+ * URI for the WebTestClient request in a test scenario.
+ * <p>
+ * It processes the URI expression by taking into account any path parameters, query parameters, and matrix parameters
+ * that may be part of the test case. The generated URI expression is then appended to the statement, which is used
+ * to build the test code.
+ * </p>
+ * <p>
+ * The generated code includes a call to {@code uri()} with the appropriate URI expression.
+ * </p>
+ *
+ * @author <a href="mailto:agsn10@hotmail.com">Antonio Neto</a> [<()>] – Initial implementation.
+ * @since 1.0
+ * @copyright 2025 Kelari. All rights reserved.
+ */
+public class UriHandler implements FluentMethodSpecHandler {
+
+    /**
+     * Handles the generation of the URI expression for the test, incorporating any path, query, and matrix parameters
+     * specified in the test case. The URI expression is then added to the WebTestClient request statement.
+     *
+     * @param statement         the {@link StringBuilder} used to build the generated test code
+     * @param args             the list of arguments that are added to the statement (not used here)
+     * @param spec             the specification for the test scenario
+     * @param test             the individual test case containing the URI parameters
+     * @param fullPath         the full path of the test, which is used to prepare the URI expression
+     */
+    @Override
+    public void handle(StringBuilder statement,
+                       List<Object> args,
+                       SpecScenariosTest spec,
+                       CaseTest test,
+                       String fullPath) {
+        String uriExpr = MethodGenerationHelper.prepareUriExpression(
+                fullPath,
+                Optional.ofNullable(test.getMethodParameters()).map(ParameterMetadataTest::getPathParams).orElse(null),
+                Optional.ofNullable(test.getMethodParameters()).map(ParameterMetadataTest::getQueryParams).orElse(null),
+                Optional.ofNullable(test.getMethodParameters()).map(ParameterMetadataTest::getMatrixParams).orElse(null)
+        );
+        statement.append("\n\t.uri(").append(uriExpr).append(")");
+    }
+}

--- a/src/main/java/io/github/kelari/atg/process/handler/expectations/ExpectCookieHandler.java
+++ b/src/main/java/io/github/kelari/atg/process/handler/expectations/ExpectCookieHandler.java
@@ -1,0 +1,57 @@
+package io.github.kelari.atg.process.handler.expectations;
+
+import io.github.kelari.atg.model.CaseTest;
+import io.github.kelari.atg.model.Cookie;
+import io.github.kelari.atg.model.SpecScenariosTest;
+import io.github.kelari.atg.process.handler.FluentMethodSpecHandler;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Implementation of {@link FluentMethodSpecHandler} that generates
+ * test expectations for HTTP cookies returned in the response.
+ * <p>
+ * This handler processes the list of expected cookies defined in the
+ * {@link CaseTest} and appends appropriate `.expectCookie().valueEquals(...)`
+ * statements to the generated test method.
+ *
+ * <p>Example generated output:
+ * <pre>{@code
+ * .expectCookie().valueEquals("sessionId", "abc123")
+ * }</pre>
+ *
+ * This helps to assert that a cookie with the given name and value
+ * is present in the HTTP response.
+ *
+ * @author <a href="mailto:agsn10@hotmail.com">Antonio Neto</a> [<()>] – Initial implementation.
+ * @since 1.0
+ * @copyright 2025 Kelari. All rights reserved.
+ */
+public class ExpectCookieHandler implements FluentMethodSpecHandler {
+
+    /**
+     * Appends cookie value assertions to the given statement builder if any
+     * expected cookies are present in the test case.
+     *
+     * @param statement the StringBuilder where the test method is being composed
+     * @param args the list of arguments (used for templating in code generation)
+     * @param spec the specification containing all scenarios
+     * @param test the individual test case being processed
+     * @param fullPath the full endpoint path being tested (unused here)
+     */
+    @Override
+    public void handle(StringBuilder statement,
+                       List<Object> args,
+                       SpecScenariosTest spec,
+                       CaseTest test,
+                       String fullPath) {
+        if (Objects.nonNull(test.getExpectedCookies())) {
+            for (Cookie cookie : test.getExpectedCookies()) {
+                statement.append("\n\t.expectCookie().valueEquals($S, $S)");
+                args.add(cookie.getName());
+                args.add(cookie.getValue());
+            }
+        }
+    }
+}

--- a/src/main/java/io/github/kelari/atg/process/handler/expectations/ExpectHeaderHandler.java
+++ b/src/main/java/io/github/kelari/atg/process/handler/expectations/ExpectHeaderHandler.java
@@ -1,0 +1,62 @@
+package io.github.kelari.atg.process.handler.expectations;
+
+import com.squareup.javapoet.CodeBlock;
+import io.github.kelari.atg.model.CaseTest;
+import io.github.kelari.atg.model.Header;
+import io.github.kelari.atg.model.SpecScenariosTest;
+import io.github.kelari.atg.process.handler.FluentMethodSpecHandler;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Implementation of {@link FluentMethodSpecHandler} responsible for generating
+ * expectations for HTTP headers in the response.
+ * <p>
+ * This handler processes the list of expected headers defined in a {@link CaseTest}
+ * and generates Java code to assert that the response contains the expected header
+ * names and values.
+ *
+ * <p>Example generated output:
+ * <pre>{@code
+ * .expectHeader().valueEquals("X-Custom-Header", "value1", "value2")
+ * }</pre>
+ *
+ * <p>This class uses {@link CodeBlock} to build the comma-separated list of header values
+ * for correct code generation via JavaPoet.
+ *
+ * @author <a href="mailto:agsn10@hotmail.com">Antonio Neto</a> [<()>] – Initial implementation.
+ * @since 1.0
+ * @copyright 2025 Kelari. All rights reserved.
+ */
+public class ExpectHeaderHandler implements FluentMethodSpecHandler {
+
+    /**
+     * Appends header assertions to the test method's statement builder if
+     * any expected headers are defined in the test case.
+     *
+     * @param statement the builder accumulating the test method body
+     * @param args the list of arguments to be used with code templates
+     * @param spec the scenario specification being processed
+     * @param test the individual test case
+     * @param fullPath the full endpoint path (not used directly in this handler)
+     */
+    @Override
+    public void handle(StringBuilder statement,
+                       List<Object> args,
+                       SpecScenariosTest spec,
+                       CaseTest test,
+                       String fullPath) {
+        if (Objects.nonNull(test.getExpectedHeaders())) {
+            for (Header header : test.getExpectedHeaders()) {
+                statement.append("\n\t.expectHeader().valueEquals($S, $L)");
+                args.add(header.getName());
+                args.add(CodeBlock.of("$L", Arrays.stream(header.getValues())
+                        .map(s -> "\"" + s + "\"")
+                        .collect(Collectors.joining(", "))));
+            }
+        }
+    }
+}

--- a/src/main/java/io/github/kelari/atg/process/handler/expectations/ExpectJsonPathHandler.java
+++ b/src/main/java/io/github/kelari/atg/process/handler/expectations/ExpectJsonPathHandler.java
@@ -1,0 +1,162 @@
+package io.github.kelari.atg.process.handler.expectations;
+
+import com.squareup.javapoet.ClassName;
+import io.github.kelari.atg.annotation.MatcherType;
+import io.github.kelari.atg.model.CaseTest;
+import io.github.kelari.atg.model.JsonPath;
+import io.github.kelari.atg.model.SpecScenariosTest;
+import io.github.kelari.atg.process.handler.FluentMethodSpecHandler;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Fluent handler responsible for generating WebTestClient assertions
+ * based on JSONPath expressions defined in the test metadata.
+ *
+ * Supports a variety of matcher types including standard Hamcrest matchers,
+ * class instance checks, negations, and custom matcher injection.
+ *
+ * @author <a href="mailto:agsn10@hotmail.com">Antonio Neto</a> [<()>] – Initial implementation.
+ * @since 1.0
+ * @copyright 2025 Kelari. All rights reserved.
+ */
+public class ExpectJsonPathHandler implements FluentMethodSpecHandler {
+
+    @Override
+    public void handle(StringBuilder statement,
+                       List<Object> args,
+                       SpecScenariosTest spec,
+                       CaseTest test,
+                       String fullPath) {
+
+        Set<JsonPath> paths = test.getJsonPaths();
+        if (paths == null || paths.isEmpty()) return;
+
+        boolean first = true;
+
+        for (JsonPath jsonPath : paths) {
+            if (jsonPath.getPath().isBlank() || jsonPath.getType() == null) continue;
+
+            if (first) {
+                statement.append("\n\t.expectBody()");
+                first = false;
+            }
+
+            statement.append("\n\t.jsonPath($S)");
+            args.add(jsonPath.getPath());
+
+            MatcherType type = jsonPath.getType();
+            String value = jsonPath.getValue();
+            String matcherClass = jsonPath.getMatcherClass();
+
+            statement.append(".value(");
+            switch (type) {
+                case NOT_NULL_VALUE -> {
+                    statement.append("$T.notNullValue()");
+                    args.add(org.hamcrest.Matchers.class);
+                }
+                case NULL_VALUE -> {
+                    statement.append("$T.nullValue()");
+                    args.add(org.hamcrest.Matchers.class);
+                }
+                case EQUAL_TO -> {
+                    statement.append("$T.equalTo($S)");
+                    args.add(org.hamcrest.Matchers.class);
+                    args.add(value);
+                }
+                case CONTAINS_STRING -> {
+                    statement.append("$T.containsString($S)");
+                    args.add(org.hamcrest.Matchers.class);
+                    args.add(value);
+                }
+                case STARTS_WITH -> {
+                    statement.append("$T.startsWith($S)");
+                    args.add(org.hamcrest.Matchers.class);
+                    args.add(value);
+                }
+                case ENDS_WITH -> {
+                    statement.append("$T.endsWith($S)");
+                    args.add(org.hamcrest.Matchers.class);
+                    args.add(value);
+                }
+                case GREATER_THAN -> {
+                    statement.append("$T.greaterThan($L)");
+                    args.add(org.hamcrest.Matchers.class);
+                    args.add(parseNumber(value));
+                }
+                case LESS_THAN -> {
+                    statement.append("$T.lessThan($L)");
+                    args.add(org.hamcrest.Matchers.class);
+                    args.add(parseNumber(value));
+                }
+                case INSTANCE_OF -> {
+                    try {
+                        Class<?> clazz = Class.forName(value);
+                        statement.append("$T.instanceOf($T.class)");
+                        args.add(org.hamcrest.Matchers.class);
+                        args.add(clazz);
+                    } catch (ClassNotFoundException e) {
+                        throw new IllegalArgumentException("Class not found: " + value);
+                    }
+                }
+                case NOT -> {
+                    statement.append("$T.not($T.equalTo($S))");
+                    args.add(org.hamcrest.Matchers.class);
+                    args.add(org.hamcrest.Matchers.class);
+                    args.add(value);
+                }
+                case ANY_OF -> {
+                    String[] values = value.split(",");
+                    statement.append("$T.anyOf(");
+                    args.add(org.hamcrest.Matchers.class);
+                    for (int i = 0; i < values.length; i++) {
+                        statement.append("$T.equalTo($S)");
+                        args.add(org.hamcrest.Matchers.class);
+                        args.add(values[i].trim());
+                        if (i < values.length - 1) statement.append(", ");
+                    }
+                    statement.append(")");
+                }
+                case CONTAINS -> {
+                    String[] values = value.split(",");
+                    statement.append("$T.contains(");
+                    args.add(org.hamcrest.Matchers.class);
+                    for (int i = 0; i < values.length; i++) {
+                        statement.append("$T.equalTo($S)");
+                        args.add(org.hamcrest.Matchers.class);
+                        args.add(values[i].trim());
+                        if (i < values.length - 1) statement.append(", ");
+                    }
+                    statement.append(")");
+                }
+                case HAS_ITEM -> {
+                    statement.append("$T.hasItem($S)");
+                    args.add(org.hamcrest.Matchers.class);
+                    args.add(value);
+                }
+                case CUSTOM_CLASS -> {
+                    if (matcherClass == null)
+                        throw new IllegalStateException("CUSTOM_CLASS requires a valid matcherClass.");
+                    statement.append("new $T()");
+                    args.add(ClassName.bestGuess(matcherClass));
+                }
+                default -> {
+                    statement.append("$T.anything()");
+                    args.add(org.hamcrest.Matchers.class);
+                }
+            }
+
+            statement.append(")");
+        }
+    }
+
+    private static Number parseNumber(String input) {
+        try {
+            if (input.contains(".")) return Double.parseDouble(input);
+            return Integer.parseInt(input);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid numeric value: " + input);
+        }
+    }
+}

--- a/src/main/java/io/github/kelari/atg/util/Constants.java
+++ b/src/main/java/io/github/kelari/atg/util/Constants.java
@@ -36,6 +36,22 @@ public final class Constants {
         public static final String PATCH_MAPPING = "PatchMapping";
         public static final String HEAD_MAPPING = "HeadMapping";
     }
+
+    public final class AnnotationFileds {
+        public static final String DISPLAY_NAME = "displayName";
+        public static final String ORDER = "order";
+        public static final String TIMEOUT = "timeout";
+        public static final String EXPECTED_STATUS_CODE = "expectedStatusCode";
+        public static final String REQUIRES_AUTH = "requiresAuth";
+        public static final String DATA_PROVIDER_CLASS_NAME = "dataProviderClassName";
+        public static final String REPEAT = "repeat";
+        public static final String ENABLE_LOGGING = "enableLogging";
+        public static final String RESPONSE_TIMEOUT_SECONDS = "responseTimeoutSeconds";
+        public static final String EXPECTED_HEADERS = "expectedHeaders";
+        public static final String EXPECTED_COOKIES = "expectedCookies";
+        public static final String JSON_PATHS = "jsonPaths";
+    }
+
     public final class ParameterAnnotation {
         public static final String PATH_VARIABLE = "org.springframework.web.bind.annotation.PathVariable";
         public static final String REQUEST_PARAM = "org.springframework.web.bind.annotation.RequestParam";
@@ -82,11 +98,20 @@ public final class Constants {
         public static final ClassName ORDER = ClassName.get("org.junit.jupiter.api", "Order");
         public static final ClassName TIMEOUT = ClassName.get("org.junit.jupiter.api", "Timeout");
         public static final ClassName DISPLAY_NAME = ClassName.get("org.junit.jupiter.api", "DisplayName");
+        public static final ClassName REPEAT = ClassName.get("org.junit.jupiter.api", "RepeatedTest");
         public static final ClassName BEFORE_EACH = ClassName.get("org.junit.jupiter.api", "BeforeEach");
+        public static final ClassName MATCHERS = ClassName.get("org.hamcrest", "Matchers");
+        public static final ClassName BEFORE_ALL = ClassName.get("org.junit.jupiter.api", "BeforeAll");
+
+        public static final ClassName MATCHER_REGISTRY = ClassName.get("io.github.kelari.atg.annotation", "MatcherRegistry");
+
+        public static final ClassName DURATION = ClassName.get("java.time", "Duration");
+
         // Spring WebFlux
         public static final ClassName BODY_INSERTERS = ClassName.get("org.springframework.web.reactive.function", "BodyInserters");
         // Spring Web Test Client
         public static final ClassName WEB_TEST_CLIENT = ClassName.get("org.springframework.test.web.reactive.server", "WebTestClient");
+        public static final ClassName EXCHANGE_FILTER_FUNCTION = ClassName.get("org.springframework.web.reactive.function.client", "ExchangeFilterFunction");
         // Spring Autowired
         public static final ClassName AUTOWIRED = ClassName.get("org.springframework.beans.factory.annotation", "Autowired");
         // Spring Boot Test WebClient

--- a/src/main/java/io/github/kelari/atg/util/Predicates.java
+++ b/src/main/java/io/github/kelari/atg/util/Predicates.java
@@ -123,6 +123,19 @@ public final class Predicates {
             }));
 
     /**
+     * Predicate that checks if the {@link ClassTest} contains methods
+     * that explicitly enable logging.
+     * <p>
+     * Used to determine if logging should be included in the test setup.
+     */
+    public static final Predicate<ClassTest> SHOULD_GENERATE_LOGGING_METHODS = classTest ->
+            classTest.entrySet().stream()
+                    .map(Map.Entry::getValue)
+                    .filter(Objects::nonNull)
+                    .flatMap(spec -> spec.getCaseTestList().stream())
+                    .anyMatch(CaseTest::isEnableLogging);
+
+    /**
      * Predicate that verifies if any {@link CaseTest} in the given {@link ClassTest}
      * explicitly requires authentication (i.e., {@code requiresAuth = true}).
      * <p>


### PR DESCRIPTION
- Definir uma lista de expressões JSONPath esperadas e seus respectivos valores a serem validados no corpo da resposta da API.
- Habilitar ou desabilitar o log para este caso de teste específico. Útil para depuração ou rastreamento de detalhes da execução.
- Indicar se o caso de teste deve ser executado como um teste parametrizado. Útil ao executar a mesma lógica com diferentes entradas.
- Definir a lista de cabeçalhos HTTP esperados na resposta. Útil para validar metadados da resposta.
- Definir a lista de cookies HTTP esperados na resposta.
- Definir quantas vezes o teste deve ser executado consecutivamente. Útil para testes de estabilidade ou tentativas repetidas.
- Definir a duração máxima de espera por uma resposta, em segundos. Substitui o tempo limite global, se especificado.

issues:
- Criar package para a classe de teste se não existir.